### PR TITLE
Fix exception handling change to pass results on success

### DIFF
--- a/cloudformation/functions/slack_triage_bot_api/app.py
+++ b/cloudformation/functions/slack_triage_bot_api/app.py
@@ -460,6 +460,7 @@ def lambda_handler(event: dict, context: dict) -> dict:
                         event.get('identityConfidence')
                     )
                 except SlackException as e:
-                    return {'result': e}
+                    result = e
         except Exception as e:
-            return {'result': str(e)}
+            result = str(e)
+        return result


### PR DESCRIPTION
Fix the change introduced in 5d0ba052156c5613c2500d62059b66ddace9c2ac which
fails to pass the result back to the caller upon success.